### PR TITLE
feat: add modal item form and full image display

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,7 +28,13 @@
     function ItemCard({ item, onDelete }) {
       return (
         <div className="bg-white rounded-2xl shadow-lg overflow-hidden flex flex-col">
-          <img src={item.image} alt={item.title} className="w-full h-48 object-cover" />
+          <div className="w-full h-48 bg-gray-100 flex items-center justify-center">
+            <img
+              src={item.image}
+              alt={item.title}
+              className="max-h-full max-w-full object-contain"
+            />
+          </div>
           <div className="p-4 flex-1 flex flex-col">
             <h2 className="text-xl font-semibold mb-1">{item.title}</h2>
             <p className="text-sm text-gray-500 mb-1">{item.condition}</p>
@@ -49,7 +55,7 @@
       );
     }
 
-    function ItemForm({ onAdd }) {
+    function ItemForm({ onAdd, onCancel }) {
       const [title, setTitle] = useState('');
       const [description, setDescription] = useState('');
       const [condition, setCondition] = useState('Like New');
@@ -151,18 +157,28 @@
             placeholder="Notes (optional)"
             className="border p-2 rounded w-full"
           />
-          <button
-            type="submit"
-            className="self-end bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded"
-          >
-            Add Item
-          </button>
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="bg-gray-300 hover:bg-gray-400 text-gray-700 px-4 py-2 rounded"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded"
+            >
+              Add Item
+            </button>
+          </div>
         </form>
       );
     }
 
     function App() {
       const [items, setItems] = useState([]);
+      const [showForm, setShowForm] = useState(false);
 
       useEffect(() => {
         const stored = localStorage.getItem('inventoryItems');
@@ -173,14 +189,31 @@
         localStorage.setItem('inventoryItems', JSON.stringify(items));
       }, [items]);
 
-      const addItem = (item) => setItems((prev) => [...prev, item]);
+      const addItem = (item) => {
+        setItems((prev) => [...prev, item]);
+        setShowForm(false);
+      };
       const deleteItem = (id) =>
         setItems((prev) => prev.filter((item) => item.id !== id));
 
       return (
         <div className="max-w-7xl mx-auto">
           <h1 className="text-3xl font-bold mb-6 text-center">Sell Your Stuff</h1>
-          <ItemForm onAdd={addItem} />
+          <div className="mb-4 flex justify-end">
+            <button
+              onClick={() => setShowForm(true)}
+              className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded"
+            >
+              New
+            </button>
+          </div>
+          {showForm && (
+            <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+              <div className="bg-white rounded-lg p-4 w-full max-w-md">
+                <ItemForm onAdd={addItem} onCancel={() => setShowForm(false)} />
+              </div>
+            </div>
+          )}
           <div className="overflow-y-auto max-h-[70vh]">
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
               {items.map((item) => (


### PR DESCRIPTION
## Summary
- open a modal with a new item form after clicking **New** and hide it on submit or cancel
- show item images fully within cards using object-contain and a neutral background

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689148fa37d8833084e5890cf11630ea