### PR TITLE
Refine new item modal and add image preview

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -118,7 +118,7 @@
       return (
         <form
           onSubmit={handleSubmit}
-          className="bg-white p-4 rounded-lg shadow-md mb-6 flex flex-col gap-4"
+          className="bg-white p-6 rounded-lg shadow-lg w-full max-w-md flex flex-col gap-4"
         >
           <input
             type="file"
@@ -127,6 +127,13 @@
             className="file:mr-4 file:py-2 file:px-4 file:rounded file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100"
             required
           />
+          {image && (
+            <img
+              src={image}
+              alt="Preview"
+              className="w-full max-h-60 object-contain rounded"
+            />
+          )}
           <input
             type="text"
             value={title}
@@ -209,9 +216,7 @@
           </div>
           {showForm && (
             <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
-              <div className="bg-white rounded-lg p-4 w-full max-w-md">
-                <ItemForm onAdd={addItem} onCancel={() => setShowForm(false)} />
-              </div>
+              <ItemForm onAdd={addItem} onCancel={() => setShowForm(false)} />
             </div>
           )}
           <div className="overflow-y-auto max-h-[70vh]">


### PR DESCRIPTION
## Summary
- clean up new-item modal by removing extra wrapper to avoid double border
- show a preview of the uploaded image within the form

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68928b34285083308a3dc7ae720d4881