### PR TITLE
Add Playwright-based Craigslist poster script

### DIFF
--- a/craigslistPoster.js
+++ b/craigslistPoster.js
@@ -1,0 +1,20 @@
+const { chromium } = require('playwright');
+
+(async () => {
+  const browser = await chromium.launch({ headless: false }); // false for debugging
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  await page.goto('https://accounts.craigslist.org/login');
+
+  // Pause so you can manually log in (or automate it later)
+  console.log('Please log in manually...');
+  await page.pause();
+
+  // After login, navigate to post form
+  await page.goto('https://post.craigslist.org/c/sfo');
+
+  // Add further steps later...
+
+  await browser.close();
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,10 @@
       "license": "ISC",
       "dependencies": {
         "express": "^5.1.0",
+        "playwright": "^1.54.2",
         "sqlite3": "^5.1.7"
-      }
+      },
+      "devDependencies": {}
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
@@ -699,6 +701,20 @@
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "license": "ISC",
       "optional": true
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -1480,6 +1496,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.54.2.tgz",
+      "integrity": "sha512-Hu/BMoA1NAdRUuulyvQC0pEqZ4vQbGfn8f7wPXcnqQmM+zct9UliKxsIkLNmz/ku7LElUNqmaiv1TG/aL5ACsw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.54.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.54.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.54.2.tgz",
+      "integrity": "sha512-n5r4HFbMmWsB4twG7tJLDN9gmBUeSPcsBZiWSE4DnYz9mJMAFqr2ID7+eGC9kpEnxExJ1epttwR59LEWCk8mtA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/prebuild-install": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "type": "commonjs",
   "dependencies": {
     "express": "^5.1.0",
+    "playwright": "^1.54.2",
     "sqlite3": "^5.1.7"
   }
 }


### PR DESCRIPTION
## Summary
- install Playwright and add dependency
- add initial `craigslistPoster.js` script to navigate Craigslist login and post page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68928efbdc9c833094866fe5e84722e1