### PR TITLE
Add Craigslist location and category selection

### DIFF
--- a/craigslistPoster.js
+++ b/craigslistPoster.js
@@ -16,10 +16,18 @@ const { chromium } = require('playwright');
   await page.fill('#inputPassword', password);
   await page.click('button[type="submit"]');
 
-  // After login, navigate to post form
-  await page.goto('https://post.craigslist.org/c/sfo');
+  // After login, navigate to main post page
+  await page.goto('https://post.craigslist.org/');
 
-  // Add further steps later...
+  // Select the desired location (e.g., San Francisco Bay Area)
+  await page.click('a[href*="/c/sfo"]');
+
+  // Choose the posting category (e.g., for sale by owner)
+  await page.click('input[value="fso"]');
+  await page.click('button[type="submit"]');
+
+  // Pause so we can inspect the state in the Playwright inspector
+  await page.pause();
 
   await browser.close();
 })();


### PR DESCRIPTION
## Summary
- navigate to Craigslist post page and choose the SF Bay Area location
- select the "for sale by owner" posting category and pause for inspection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893bd5c409c8330a630c2630c4828f7